### PR TITLE
Add start and reset controls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,9 @@
 <template>
-    <GaltonBoard />
+    <div>
+        <button @click="start">Start</button>
+        <button @click="reset">Reset</button>
+        <GaltonBoard ref="board" />
+    </div>
 </template>
 
 <script lang="ts">
@@ -9,6 +13,14 @@ import GaltonBoard from "./components/GaltonBoard.vue";
 export default defineComponent({
     name: "App",
     components: { GaltonBoard },
+    methods: {
+        start() {
+            (this.$refs.board as any).start();
+        },
+        reset() {
+            (this.$refs.board as any).reset();
+        },
+    },
 });
 </script>
 


### PR DESCRIPTION
## Summary
- expose Start and Reset buttons in the main `App` component
- add runtime state to `GaltonBoard` so the engine can be started or cleared
- implement `start()` and `reset()` methods to control the simulation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68407c0b2ffc832d8e79dcbb0a80ffe5