### PR TITLE
Improve reset behavior

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,9 @@
 <template>
-    <GaltonBoard />
+    <div>
+        <button @click="start">Start</button>
+        <button @click="reset">Reset</button>
+        <GaltonBoard ref="board" />
+    </div>
 </template>
 
 <script lang="ts">
@@ -9,6 +13,14 @@ import GaltonBoard from "./components/GaltonBoard.vue";
 export default defineComponent({
     name: "App",
     components: { GaltonBoard },
+    methods: {
+        start() {
+            (this.$refs.board as any).start();
+        },
+        reset() {
+            (this.$refs.board as any).reset();
+        },
+    },
 });
 </script>
 

--- a/src/components/GaltonBoard.vue
+++ b/src/components/GaltonBoard.vue
@@ -77,11 +77,16 @@ export default defineComponent({
             },
             // Simulation Parameters
             simulationParams: {
-                isRunning: true,
+                isRunning: false,
                 ballCounter: 0,
                 ballColorIndex: 0,
                 gravity: 1.5,
             },
+            // Runtime objects
+            engine: null as Matter.Engine | null,
+            runner: null as Matter.Runner | null,
+            render: null as Matter.Render | null,
+            ballInterval: null as number | null,
         };
     },
     computed: {
@@ -321,7 +326,7 @@ export default defineComponent({
         },
         simulate(engine: Matter.Engine) {
             // Generate a ball every spawnInterval milliseconds until we reach the configured number
-            setInterval(() => {
+            this.ballInterval = window.setInterval(() => {
                 if (this.simulationParams.isRunning) {
                     const ball = this.createBall();
 
@@ -339,40 +344,84 @@ export default defineComponent({
                 }
             }, this.ballsConfig.spawnInterval);
         },
+        initializeBoard() {
+            if (this.engine) {
+                return;
+            }
+
+            this.engine = this.Engine.create({ enableSleeping: true });
+            this.engine.gravity.y = this.simulationParams.gravity;
+
+            this.render = this.Render.create({
+                element: document.getElementById("galtonCanvasContainer") as HTMLElement,
+                engine: this.engine,
+                options: {
+                    width: this.canvasConfig.width,
+                    height: this.canvasConfig.height,
+                    wireframes: false,
+                    background: this.canvasConfig.backgroundColor,
+                },
+            });
+
+            this.World.add(this.engine.world, [
+                this.borderTop,
+                this.borderBottom,
+                this.borderRight,
+                this.borderLeft,
+                this.rampLeftTop,
+                this.rampLeftBottom,
+                this.rampRightTop,
+                this.rampRightBottom,
+                ...this.nails,
+                ...this.walls,
+            ]);
+
+            this.Render.run(this.render);
+        },
+        start() {
+            this.reset();
+
+            if (!this.engine || !this.render) {
+                this.initializeBoard();
+            }
+
+            this.simulationParams.isRunning = true;
+            this.simulationParams.ballCounter = 0;
+
+            this.simulate(this.engine as Matter.Engine);
+
+            this.runner = this.Runner.create();
+            this.Runner.run(this.runner, this.engine as Matter.Engine);
+            this.Render.run(this.render as Matter.Render);
+        },
+        reset() {
+            this.simulationParams.isRunning = false;
+            this.simulationParams.ballCounter = 0;
+            this.simulationParams.ballColorIndex = 0;
+
+            if (this.ballInterval) {
+                clearInterval(this.ballInterval);
+                this.ballInterval = null;
+            }
+            if (this.runner) {
+                this.Runner.stop(this.runner);
+                this.runner = null;
+            }
+            if (this.render) {
+                this.Render.stop(this.render);
+            }
+            if (this.engine) {
+                Matter.World.clear(this.engine.world, true);
+                Matter.Engine.clear(this.engine);
+            }
+            if (this.render && this.engine) {
+                // draw the static board after clearing balls
+                this.Render.world(this.render);
+            }
+        },
     },
     mounted() {
-        const engine = this.Engine.create({ enableSleeping: true });
-        engine.gravity.y = this.simulationParams.gravity;
-
-        const render = this.Render.create({
-            element: document.getElementById("galtonCanvasContainer") as HTMLElement,
-            engine: engine,
-            options: {
-                width: this.canvasConfig.width,
-                height: this.canvasConfig.height,
-                wireframes: false,
-                background: this.canvasConfig.backgroundColor,
-            },
-        });
-
-        this.World.add(engine.world, [
-            this.borderTop,
-            this.borderBottom,
-            this.borderRight,
-            this.borderLeft,
-            this.rampLeftTop,
-            this.rampLeftBottom,
-            this.rampRightTop,
-            this.rampRightBottom,
-            ...this.nails,
-            ...this.walls,
-        ]);
-
-        this.simulate(engine);
-
-        const runner = this.Runner.create();
-        this.Runner.run(runner, engine);
-        this.Render.run(render);
+        this.initializeBoard();
     },
 });
 </script>


### PR DESCRIPTION
## Summary
- ensure the reset button only clears balls
- redraw the board after clearing so the canvas doesn't keep old frames

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68407c0b2ffc832d8e79dcbb0a80ffe5